### PR TITLE
Fix instant add

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ pip: $(pip)  ## upgrade pip
 
 .PHONY: pip
 
-self_package := $(VENV_ROOT)/lib/python*/site-packages/__editable__.$(package_name)*.pth
+self_package_pattern := $(VENV_ROOT)/lib/python*/site-packages/__editable__.$(package_name)*.pth
+self_package := $(call safe-shell,echo $(self_package_pattern) | xargs -n1 | grep -v '\-bak' | tail -1)
 
 $(self_package): $(pip)
 	$(activate_venv) \

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,10 @@ description = mpv-cal installs services that allow scheduling media using calend
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = microchipster
-license = GPLv3
+license = GPL-2.0
 license_files = LICENSE
 classifiers =
+    License :: OSI Approved :: GNU General Public License v2 (GPLv2)
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
 

--- a/src/mpv_calendar/__main__.py
+++ b/src/mpv_calendar/__main__.py
@@ -26,6 +26,11 @@ def main() -> None:
     """Start the server."""
     port = int(sys.argv[1]) if len(sys.argv) > 1 else Constant.port
 
+    if is_running_from_venv():
+        print("Running from virtual environment.")
+    else:
+        print("Running from system installation.")
+
     uvicorn.run(
         app,
         host=IP_ADDRESS,

--- a/src/mpv_calendar/scripts/install-mpv-calendar-service
+++ b/src/mpv_calendar/scripts/install-mpv-calendar-service
@@ -143,17 +143,18 @@ viewer_service_name="$(mpv-calendar-constant viewer_service)"
 controller_service_name="$(mpv-calendar-constant controller_service)"
 watcher_service_name="$(mpv-calendar-constant watcher_service)"
 
-systemctl --user stop "$viewer_service_name"
-systemctl --user disable "$viewer_service_name"
-systemctl --user stop "$controller_service_name"
-systemctl --user disable "$controller_service_name"
-systemctl --user stop "$watcher_service_name"
-systemctl --user disable "$watcher_service_name"
+# TODO: check if the service exists first instead of unilaterally passing
+systemctl --user stop "$viewer_service_name" || :
+systemctl --user disable "$viewer_service_name" || :
+systemctl --user stop "$controller_service_name" || :
+systemctl --user disable "$controller_service_name" || :
+systemctl --user stop "$watcher_service_name" || :
+systemctl --user disable "$watcher_service_name" || :
 
 poll_delay=1  # seconds
 
 viewer_service_script="$(which "$viewer_service_name")"
-viewer_script="bash -c 'PATH=$PREFIX/bin:$PATH MPV_CALENDAR_GEOMETRY=$geometry DISPLAY=$display tmux-service $poll_delay $viewer_service_name $viewer_service_script'"
+viewer_script="bash -c 'PATH=$PREFIX/bin:$PATH MPV_CALENDAR_GEOMETRY=$geometry DISPLAY=$display tmux-service $poll_delay $viewer_service_name $viewer_service_script mpv'"
 watcher_script="bash -c 'PATH=$PREFIX/bin:$PATH $watcher_service_name'"
 controller_script="bash -c 'PATH=$PREFIX/bin:$PATH $controller_service_name $port'"
 
@@ -217,10 +218,6 @@ _init_service () {
     systemctl --user daemon-reload
 }
 
-_init_service "$viewer_service_name"
-_init_service "$watcher_service_name"
-_init_service "$controller_service_name"
-
 # setup nginx to handle rtmp
 if ! grep -q 'rtmp {' /etc/nginx/nginx.conf
 then
@@ -248,4 +245,12 @@ sudo systemctl enable nginx.service --no-pager
 sudo systemctl start nginx.service --no-pager
 sudo systemctl status -l nginx.service --no-pager
 
-init-always-on-display 315576000000 "$display" "$rotation"
+# display shouldn't necessarily have to be available to install
+if DISPLAY="$display" xrandr 2>/dev/null
+then
+    init-always-on-display 315576000000 "$display" "$rotation"
+fi
+
+_init_service "$viewer_service_name"
+_init_service "$watcher_service_name"
+_init_service "$controller_service_name"

--- a/src/mpv_calendar/scripts/install-tmux-plugins
+++ b/src/mpv_calendar/scripts/install-tmux-plugins
@@ -63,7 +63,7 @@ set-option -g set-clipboard on
 # color
 set -ga terminal-overrides ",xterm-256color:Tc"
 set -g default-terminal "tmux-256color"
-set -g default-shell ~/bin/shell/zsh-tmux
+set -g default-shell /bin/bash
 
 # if run as "tmux attach", create a session if one does not already exist
 new-session -n \$HOST

--- a/src/mpv_calendar/scripts/mpv-calendar-remote-installer
+++ b/src/mpv_calendar/scripts/mpv-calendar-remote-installer
@@ -13,7 +13,7 @@ then
     # TODO: un-hardcode url and params
     git_url=https://github.com/Studio45sf/mpv-cal.git
     package_name=mpv_calendar
-    branch=master
+    branch="${MPV_CALENDAR_VERSION-main}"
 
     commit="$(git ls-remote "$git_url" "refs/heads/$branch" | awk '{print $1}')"
 
@@ -45,7 +45,7 @@ MPV_CALENDAR_UPTIME="${MPV_CALENDAR_UPTIME-180}"
 MPV_CALENDAR_DISPLAY="${MPV_CALENDAR_DISPLAY-:0}"
 MPV_CALENDAR_ROTATION="${MPV_CALENDAR_ROTATION-normal}"
 MPV_CALENDAR_PORT="${MPV_CALENDAR_PORT-8080}"
-MPV_CALENDAR_START_BURST_LIMIT="${MPV_CALENDAR_START_BURST_LIMIT-20}"
+MPV_CALENDAR_START_BURST_LIMIT="${MPV_CALENDAR_START_BURST_LIMIT-40}"
 
 install-mpv-calendar-service \
     "$MPV_CALENDAR_UPTIME" \

--- a/src/mpv_calendar/scripts/mpv-calendar-viewer
+++ b/src/mpv_calendar/scripts/mpv-calendar-viewer
@@ -115,8 +115,22 @@ then
 fi
 
 # kill any other instances of mpv
+
+to_kill="$(mktemp)"
+trap 'rm -f '"$to_kill" EXIT
+
+touch "$to_kill"
+
 # shellcheck disable=2009
-ps aux | grep -v grep | grep "$mpv_socket" | grep -v -w $$ | grep -w mpv | awk '{print $2}' | xargs kill -9 || :
+ps aux | grep -v grep | grep "$mpv_socket" | grep -v -w $$ | grep -w mpv | awk '{print $2}' > "$to_kill" || :
+
+if grep -q . "$to_kill"
+then
+    echo 'Killing '"$(cat "$to_kill")"
+
+    # shellcheck disable=2009
+    xargs kill -9 < "$to_kill" || :
+fi
 
 _register_mpv_track_change_hook  # write a hook that lets us know when the track changes
 

--- a/src/mpv_calendar/scripts/mpv-calendar-watcher
+++ b/src/mpv_calendar/scripts/mpv-calendar-watcher
@@ -38,8 +38,8 @@ read_calendars () {
 
 # File to store the upcoming events
 events_file="$(mktemp)"
-
-trap 'rm -f '"$events_file" EXIT HUP INT TERM
+to_kill="$(mktemp)"
+trap 'rm -f '"$events_file"' '"$to_kill" EXIT HUP INT TERM
 
 # Start and stop unix time
 start_time=$(date +%s) # current unix time
@@ -217,8 +217,15 @@ then
     exit
 fi
 
+touch "$to_kill"
+
 # kill any other instances of this script
 # shellcheck disable=2009
-ps aux | grep -v grep | grep -v vim | grep -v -w $$ | grep -w "$(basename "$0")" | awk '{print $2}' | xargs kill -9 || :
+ps aux | grep -v grep | grep -v vim | grep -v -w $$ | grep -w "$(basename "$0")" | awk '{print $2}' > "$to_kill" || :
+
+if grep -q . "$to_kill"
+then
+    xargs kill -9 < "$to_kill" || :
+fi
 
 _watch_for_calendar_events 90 4

--- a/src/mpv_calendar/scripts/tmux-service
+++ b/src/mpv_calendar/scripts/tmux-service
@@ -13,10 +13,17 @@ PREFIX="${PREFIX-$HOME/.local}"
 PATH=$PREFIX/bin:$HOME/.cargo/bin:$HOME/go/bin:$PATH
 export PATH
 
+MPV_CALENDAR_VIEWER_TIMEOUT=${MPV_CALENDAR_VIEWER_TIMEOUT-30}
+
 poll_delay="${1?'ERROR: no poll delay given (1)'}"
 session_name="${2?'ERROR: no session name given (2)'}"
 script_path="${3?'ERROR: no script path given (3)'}"
-args="${*:4}"
+window_pattern="${4?'ERROR: no window pattern given (4)'}"
+args="${*:5}"
+
+session_start_time="$(mktemp)"
+
+trap 'rm -f '"$session_start_time" EXIT
 
 # shellcheck disable=2009
 if ! ps aux | grep tmux | grep -q server
@@ -27,6 +34,32 @@ fi
 # Function to check if the script process is running
 is_script_running () {
     pgrep -f "$script_path"
+
+    local current_timestamp
+    local file_timestamp
+    local time_difference
+
+    # Current Unix timestamp
+    current_timestamp=$(date +%s)
+
+    if ! test -f "$session_start_time"
+    then
+        echo "$current_timestamp" > "$session_start_time"
+    fi
+
+    file_timestamp="$(cat "$session_start_time")"
+
+    # Calculate the time difference in seconds
+    time_difference=$((current_timestamp - file_timestamp))
+
+    # Compare the time difference with the threshold (10 seconds)
+    if test "$time_difference" -ge "$MPV_CALENDAR_VIEWER_TIMEOUT"
+    then
+        if echo "$window_pattern" | grep -q .
+        then
+            DISPLAY="${DISPLAY-:0}" xdotool search "$window_pattern" | grep -q .
+        fi
+    fi
 }
 
 # Function to check if the session is already running
@@ -37,6 +70,7 @@ is_session_running () {
 # Start the session and run the script
 start_session () {
     tmux new-session -d -s "$session_name" "$script_path" "${args[@]}"
+    date +%s > "$session_start_time"
 }
 
 stop_session () {


### PR DESCRIPTION
A few fixes here, but the main goal was to track when mpv is actually open as a window vs the process because sometimes the process stays alive but the window gets killed. Not tracking this caused the instant play to play then the window would drop out and never come back.